### PR TITLE
Remove unwanted characters from the input

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,6 +89,7 @@ HttpTemperature.prototype = {
                let value = null;
                try {
                   const value_str = this.fieldName === '' ? body : this.getFromObject(JSON.parse(body), this.fieldName, '');
+                  value_str = value_str.replace(/[^0-9.]/g, '');
                   value = Number(value_str);
                   if (value_str === '' || isNaN(value)) {
                      throw new Error('Received value is not a number: "' + value_str + '" ("' + body.substring(0, 100) + '")');

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ HttpTemperature.prototype = {
             res.on('end', () => {
                let value = null;
                try {
-                  const value_str = this.fieldName === '' ? body : this.getFromObject(JSON.parse(body), this.fieldName, '');
+                  let value_str = this.fieldName === '' ? body : this.getFromObject(JSON.parse(body), this.fieldName, '');
                   value_str = value_str.replace(/[^0-9.]/g, '');
                   value = Number(value_str);
                   if (value_str === '' || isNaN(value)) {


### PR DESCRIPTION
When the data given is for example "45.0 ºC" it doesn't work.

With `value_str = value_str.replace(/[^0-9.]/g, '');`, everything but numbers and the dot are removed, leaving a clean output.